### PR TITLE
fix: Fix auto-install failing on a fresh environment

### DIFF
--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -75,7 +75,7 @@ export async function install(context: ExtensionContext): Promise<string> {
 
 		progress.report({ message: 'Installing...'});
 
-		extractZip(lexicalZipUri, lexicalReleaseUri);
+		await extractZip(lexicalZipUri, lexicalReleaseUri);
     InstallationManifest.write(lexicalInstallationDirectoryUri);
 
     return lexicalReleaseUri.fsPath;
@@ -108,9 +108,15 @@ function ensureInstallationDirectoryExists(context: ExtensionContext): void {
 	}
 }
 
-function extractZip(zipUri: Uri, releaseUri: Uri): void {
-	fs.createReadStream(zipUri.fsPath)
-		.pipe(unzipper.Extract({ path: releaseUri.fsPath }));
+async function extractZip(zipUri: Uri, releaseUri: Uri): Promise<void> {
+	await new Promise((resolve, reject) => {
+		fs.createReadStream(zipUri.fsPath)
+			.pipe(unzipper.Extract({ path: releaseUri.fsPath }))
+			.on('close', () => {
+				resolve(undefined);
+			});
+	});
+	
 
 	fs.chmodSync(Uri.joinPath(releaseUri, 'start_lexical.sh').fsPath, 0o755);
 	fs.chmodSync(Uri.joinPath(releaseUri, 'bin', 'lexical').fsPath, 0o755);

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -104,7 +104,7 @@ function ensureInstallationDirectoryExists(context: ExtensionContext): void {
 	const installDirUri = getLexicalInstallationDirectoryUri(context);
 
 	if (!fs.existsSync(installDirUri.fsPath)) {
-		fs.mkdirSync(installDirUri.fsPath);
+		fs.mkdirSync(installDirUri.fsPath, { recursive: true	});
 	}
 }
 


### PR DESCRIPTION
Fixes the two following issues:
- The global storage folder isn't created by default
- Zip extraction is actually async, so we now wait for it to be done before trying to update permissions on installed files