### PR TITLE
fix: Make @vscode/types version compatible with engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@types/glob": "^8.1.0",
     "@types/node": "16.x",
     "@types/unzipper": "^0.10.5",
-    "@types/vscode": "^1.76.0",
+    "@types/vscode": "^1.73.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
     "@vscode/test-electron": "^2.2.3",


### PR DESCRIPTION
Fixes the issues with `@types/vscode` being incompatible with the engine version, [as reported on Discord](https://discord.com/channels/269508806759809042/918183981344772117/1113062784289230928)