### PR TITLE
feat: Support installing semantic versioned release from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,8 @@
   },
   "dependencies": {
     "axios": "^1.3.4",
+    "date-fns": "^2.30.0",
+    "semver": "^7.5.1",
     "unzipper": "^0.10.11",
     "vscode-languageclient": "^8.1.0"
   }

--- a/src/installation-manifest.ts
+++ b/src/installation-manifest.ts
@@ -1,10 +1,11 @@
 import { Uri } from "vscode";
 import * as fs from "fs";
 import Release from "./release";
+import ReleaseVersion from "./release/version";
 
 namespace InstallationManifest {
 	export interface T {
-		installedVersion: Date;
+		installedVersion: ReleaseVersion.T;
 	}
 
 	interface RawInstallationManifest {
@@ -68,19 +69,19 @@ namespace InstallationManifest {
 			rawManifest !== null &&
 			"installedVersion" in rawManifest &&
 			typeof rawManifest.installedVersion === "string" &&
-			new Date(rawManifest.installedVersion).toString() !== "Invalid Date"
+			ReleaseVersion.isValid(rawManifest.installedVersion)
 		);
 	}
 
 	function toRaw(manifest: T): RawInstallationManifest {
 		return {
-			installedVersion: manifest.installedVersion.toISOString(),
+			installedVersion: ReleaseVersion.serialize(manifest.installedVersion),
 		};
 	}
 
 	function fromRaw(manifest: RawInstallationManifest): T {
 		return {
-			installedVersion: new Date(manifest.installedVersion),
+			installedVersion: ReleaseVersion.deserialize(manifest.installedVersion),
 		};
 	}
 }

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -11,6 +11,7 @@ import { join } from "path";
 import InstallationManifest from "./installation-manifest";
 import Github from "./github";
 import Release from "./release";
+import ReleaseVersion from "./release/version";
 
 namespace LanguageServer {
 	export async function start(releasePath: string): Promise<void> {
@@ -115,7 +116,10 @@ namespace LanguageServer {
 		installationManifest: InstallationManifest.T,
 		latestRelease: Release.T
 	): boolean {
-		return installationManifest.installedVersion >= latestRelease.version;
+		return ReleaseVersion.gte(
+			installationManifest.installedVersion,
+			latestRelease.version
+		);
 	}
 
 	function getLexicalInstallationDirectoryUri(context: ExtensionContext): Uri {

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,10 +1,11 @@
 import Github from "./github";
 import { Uri } from "vscode";
+import ReleaseVersion from "./release/version";
 
 namespace Release {
 	export interface T {
 		name: string;
-		version: Date;
+		version: ReleaseVersion.T;
 		archiveUrl: Uri;
 	}
 
@@ -15,21 +16,9 @@ namespace Release {
 
 		return {
 			name: githubRelease.name,
-			version: githubReleaseNameToDate(githubRelease.name),
+			version: ReleaseVersion.fromGithubReleaseName(githubRelease.name),
 			archiveUrl: findArchiveUri(githubRelease),
 		};
-	}
-
-	function githubReleaseNameToDate(releaseName: string): Date {
-		const date = new Date(releaseName + ".000Z");
-
-		if (date.toString() === "Invalid Date") {
-			throw new Error(
-				`Release name "${releaseName} is not a valid ISO8601 timestamp without milliseconds.`
-			);
-		}
-
-		return date;
 	}
 
 	function findArchiveUri(githubRelease: Github.Release): Uri {

--- a/src/release/version.ts
+++ b/src/release/version.ts
@@ -1,0 +1,103 @@
+import { parseISO } from "date-fns";
+import * as semver from "semver";
+
+namespace ReleaseVersion {
+	export type T = Date | semver.SemVer;
+
+	export function serialize(version: ReleaseVersion.T): string {
+		if (version instanceof Date) {
+			return version.toISOString();
+		}
+
+		return version.format();
+	}
+
+	export function deserialize(rawVersion: string): T {
+		const date = deserializeToDate(rawVersion);
+		if (date !== undefined) {
+			return date;
+		}
+
+		const semanticVersion = deserializeToSemantic(rawVersion);
+		if (semanticVersion !== undefined) {
+			return semanticVersion;
+		}
+
+		throw new Error(
+			`Version "${rawVersion} is not a valid ISO8601 nor a valid semantic number.`
+		);
+	}
+
+	export function isValid(rawVersion: string): boolean {
+		return (
+			deserializeToDate(rawVersion) !== undefined ||
+			deserializeToSemantic(rawVersion) !== undefined
+		);
+	}
+
+	export function gte(left: T, right: T): boolean {
+		if (left instanceof semver.SemVer && right instanceof Date) {
+			return true;
+		}
+
+		if (left instanceof semver.SemVer && right instanceof semver.SemVer) {
+			return semver.gte(left, right);
+		}
+
+		if (left instanceof Date && right instanceof Date) {
+			return left >= right;
+		}
+
+		return false;
+	}
+
+	export function fromGithubReleaseName(releaseName: string): ReleaseVersion.T {
+		const dateVersion = githubReleaseNameToDate(releaseName);
+		if (dateVersion !== undefined) {
+			return dateVersion;
+		}
+
+		const semanticVersion = githubReleaseNameToSemanticVersion(releaseName);
+		if (semanticVersion !== undefined) {
+			return semanticVersion;
+		}
+
+		throw new Error(
+			`Release name "${releaseName} is not a valid ISO8601 timestamp without milliseconds nor a valid semantic number.`
+		);
+	}
+
+	function deserializeToDate(rawVersion: string): Date | undefined {
+		const date = parseISO(rawVersion);
+
+		if (date.toString() === "Invalid Date") {
+			return undefined;
+		}
+
+		return date;
+	}
+
+	function deserializeToSemantic(
+		rawVersion: string
+	): semver.SemVer | undefined {
+		const semanticVersion = semver.valid(rawVersion);
+
+		if (semanticVersion !== null) {
+			return new semver.SemVer(semanticVersion);
+		}
+
+		return undefined;
+	}
+
+	function githubReleaseNameToDate(releaseName: string): Date | undefined {
+		return deserializeToDate(releaseName + ".000Z");
+	}
+
+	function githubReleaseNameToSemanticVersion(
+		releaseName: string
+	): semver.SemVer | undefined {
+		return semver.coerce(releaseName) ?? undefined;
+	}
+}
+
+export default ReleaseVersion;

--- a/src/test/release.test.ts
+++ b/src/test/release.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import Github from "../github";
 import Release from "../release";
 import { URI } from "vscode-uri";
+import * as semver from "semver";
 
 describe("fromGithubRelease", () => {
 	test("should throw given github release without a name", () => {
@@ -13,7 +14,7 @@ describe("fromGithubRelease", () => {
 		expect(() => Release.fromGithubRelease(githubRelease)).toThrow();
 	});
 
-	test("should throw given github release name is not an ISO 8601 timestamp without milliseconds", () => {
+	test("should throw given github release name is not valid version", () => {
 		const githubRelease: Github.Release = {
 			name: "hello",
 			assets: [],
@@ -31,7 +32,7 @@ describe("fromGithubRelease", () => {
 		expect(() => Release.fromGithubRelease(githubRelease)).toThrow();
 	});
 
-	test("should create a release", () => {
+	test("should create a release with a date version", () => {
 		const githubReleaseName = "2023-05-27T15:48:20";
 		const githubRelease: Github.Release = {
 			name: githubReleaseName,
@@ -47,6 +48,27 @@ describe("fromGithubRelease", () => {
 		const expected: Release.T = {
 			name: githubReleaseName,
 			version: new Date(githubReleaseName + ".000Z"),
+			archiveUrl: URI.parse(githubRelease.assets[0].browser_download_url),
+		};
+		expect(release).toEqual(expected);
+	});
+
+	test("should create a release with a semantic version", () => {
+		const githubReleaseName = "v1.2.3";
+		const githubRelease: Github.Release = {
+			name: githubReleaseName,
+			assets: [
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				{ name: "lexical.zip", browser_download_url: "https://example.com" },
+			],
+		};
+
+		const release = Release.fromGithubRelease(githubRelease);
+
+		const expected: Release.T = {
+			name: githubReleaseName,
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			version: semver.coerce(githubReleaseName)!,
 			archiveUrl: URI.parse(githubRelease.assets[0].browser_download_url),
 		};
 		expect(release).toEqual(expected);

--- a/src/test/release/version.test.ts
+++ b/src/test/release/version.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "@jest/globals";
+import ReleaseVersion from "../../release/version";
+import { SemVer } from "semver";
+
+const validDate = "2023-05-27T15:48:20.000Z";
+const validSemanticVersion = "1.2.3";
+const invalidVersion = "hello";
+
+describe("serialize", () => {
+	test("should serialize a date version", () => {
+		const serialized = ReleaseVersion.serialize(new Date(validDate));
+		expect(serialized).toEqual(validDate);
+	});
+
+	test("should serialize a semantic version", () => {
+		const serialized = ReleaseVersion.serialize(
+			new SemVer(validSemanticVersion)
+		);
+		expect(serialized).toEqual(validSemanticVersion);
+	});
+});
+
+describe("deserialize", () => {
+	test("should deserialize a date version", () => {
+		const version = ReleaseVersion.deserialize(validDate);
+		expect(version).toEqual(new Date(validDate));
+	});
+
+	test("should deserialize a semantic version", () => {
+		const version = ReleaseVersion.deserialize(validSemanticVersion);
+		expect(version).toEqual(new SemVer(validSemanticVersion));
+	});
+
+	test("should throw if version is not deserializable", () => {
+		expect(() => ReleaseVersion.deserialize(invalidVersion)).toThrow();
+	});
+});
+
+describe("isValid", () => {
+	test("should accept date versions", () => {
+		expect(ReleaseVersion.isValid(validDate)).toBe(true);
+	});
+
+	test("should accept semantic versions", () => {
+		expect(ReleaseVersion.isValid(validSemanticVersion)).toBe(true);
+	});
+
+	test("should not accept invalid versions", () => {
+		expect(ReleaseVersion.isValid(invalidVersion)).toBe(false);
+	});
+});
+
+describe("gte", () => {
+	test("should be true if left side is a semantic version and right side is a date", () => {
+		const semanticVersion = new SemVer(validSemanticVersion);
+		const dateVersion = new Date(validDate);
+
+		expect(ReleaseVersion.gte(semanticVersion, dateVersion)).toBe(true);
+	});
+
+	test("should be false if left side is a date version and right side is a semantic", () => {
+		const semanticVersion = new SemVer(validSemanticVersion);
+		const dateVersion = new Date(validDate);
+
+		expect(ReleaseVersion.gte(dateVersion, semanticVersion)).toBe(false);
+	});
+
+	test("should compare two semantic versions", () => {
+		const lowerSemanticVersion = new SemVer("1.1.1");
+		const greaterSemanticVersion = new SemVer("2.2.2");
+
+		expect(
+			ReleaseVersion.gte(greaterSemanticVersion, lowerSemanticVersion)
+		).toBe(true);
+	});
+
+	test("should compare two date versions", () => {
+		const lowerDateVersion = new Date("2023-01-01T00:00:00.000Z");
+		const greaterDateVersion = new Date("2024-01-01T00:00:00.000Z");
+
+		expect(ReleaseVersion.gte(greaterDateVersion, lowerDateVersion)).toBe(true);
+	});
+});
+
+describe("fromGithubReleaseName", () => {
+	test("should parse a semantic github release name", () => {
+		const version = ReleaseVersion.fromGithubReleaseName("v1.2.3");
+
+		expect(version).toEqual(new SemVer("1.2.3"));
+	});
+
+	test("should parse a date github release name", () => {
+		const version = ReleaseVersion.fromGithubReleaseName("2023-05-27T15:48:20");
+
+		expect(version).toEqual(new Date("2023-05-27T15:48:20.000Z"));
+	});
+
+	test("should throw given invalid release name", () => {
+		expect(() => ReleaseVersion.fromGithubReleaseName("hello")).toThrow();
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.20.2"
 
+"@babel/runtime@^7.21.0":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -1420,6 +1427,13 @@ css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -3187,6 +3201,11 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -3264,7 +3283,7 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-semver@7.x, semver@^7.3.5:
+semver@7.x, semver@^7.3.5, semver@^7.5.1:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==


### PR DESCRIPTION
Adds support for installing releases from github which have a semantic version as a name rather than a date.

Support for both types of versions will be required while lexical transitions releases from date versions to semantic ones. Support for date versions will be remove some time after the transition is completed so people have time to update.