### PR TITLE
doc: Compatibility details

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "proseWrap": "always"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to the "lexical" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how
+to structure this file.
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,13 @@ code --install-extension *.vsix
 
 ## Publishing the extension
 
-1. Make sure the version number has been updated in [`package.json`](./package.json)
+1. Make sure the version number has been updated in
+   [`package.json`](./package.json)
 1. Log in to your Azure DevOps account
-   1. [Create an Azure DevOps organization](https://learn.microsoft.com/en-ca/azure/devops/organizations/accounts/create-organization?view=azure-devops#create-an-organization) if you don't already have one. The organization name doesn't matter, you simply need one to access Azure DevOps and create a Personal Access Token.
-   1. [Create a Personal Access Token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token) with the "Manage Marketplace" scope if you don't already have one.
+   1. [Create an Azure DevOps organization](https://learn.microsoft.com/en-ca/azure/devops/organizations/accounts/create-organization?view=azure-devops#create-an-organization)
+      if you don't already have one. The organization name doesn't matter, you
+      simply need one to access Azure DevOps and create a Personal Access Token.
+   1. [Create a Personal Access Token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token)
+      with the "Manage Marketplace" scope if you don't already have one.
    1. Login in to vsce: `yarn vsce:login` with your Personal Access Token
 1. Publish the extension: `yarn vsce:publish`

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ files are created).
 
 ### Known issues
 
-#### `init terminating in do_boot ({load_failed,[logger_simple_h,gen,logger_server,...`
+#### Error in output tab: `init terminating in do_boot ({load_failed,[logger_simple_h,gen,logger_server,...`
 
-When seeing this error in VSCode's Output tab, it most likely means your version
-of Erlang is incompatible with your build of Lexical. Please refer to the
-[Erlang compatibility section](#erlang) for more details.
+This error usually means your version of Erlang is incompatible with your build
+of Lexical. Please refer to the [Erlang compatibility section](#erlang) for more
+details.
 
 ### Getting help
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Lexical
 
-Lexical is a next-generation language server for the Elixir programming language.
+Lexical is a next-generation language server for the Elixir programming
+language.
 
 ## Features
 
@@ -11,38 +12,59 @@ Lexical is a next-generation language server for the Elixir programming language
 - Code Formatting
 - Completely isolated build environment
 
-For all the details on what makes Lexical stand out from other Elixir language servers, see the [language server repository](https://github.com/lexical-lsp/lexical).
+For all the details on what makes Lexical stand out from other Elixir language
+servers, see the
+[language server repository](https://github.com/lexical-lsp/lexical).
 
 ## Using the extension
 
-This extension will automatically download and install the [latest Lexical release](https://github.com/lexical-lsp/lexical/releases) from Github when starting up. You can disable this behaviour and point the extension to your own build with the [`lexical.server.releasePathOverride` configuration option](#lexicalserverreleasepathoverride).
+This extension will automatically download and install the
+[latest Lexical release](https://github.com/lexical-lsp/lexical/releases) from
+Github when starting up. You can disable this behaviour and point the extension
+to your own build with the
+[`lexical.server.releasePathOverride` configuration option](#lexicalserverreleasepathoverride).
 
 ## Configuration
 
 ### lexical.server.releasePathOverride
 
-Tells the extension to use a local release of the Lexical language server instead of the automatically installed one. Useful to work on Lexical, or use an older version.
+Tells the extension to use a local release of the Lexical language server
+instead of the automatically installed one. Useful to work on Lexical, or use an
+older version.
 
-The path should look something like `/home/username/Projects/lexical/_build/dev/rel/lexical`.
+The path should look something like
+`/home/username/Projects/lexical/_build/dev/rel/lexical`.
 
 ### Erlang and Elixir version compatibility
 
 #### Erlang
 
-Auto-installed builds of Lexical are currently only compatible with the version of Erlang they are built with. Refer to the following table to know which version that is:
+Auto-installed builds of Lexical are currently only compatible with the version
+of Erlang they are built with. Refer to the following table to know which
+version that is:
 
 | Lexical  | Erlang    |
 | -------- | --------- |
 | 0.2.2    | 24.3.4.13 |
 | >= 0.2.3 | 24.3.4.12 |
 
-Refer to the [Releases page of Lexical](https://github.com/lexical-lsp/lexical/releases) to find out what the latest version is.
+Refer to the
+[Releases page of Lexical](https://github.com/lexical-lsp/lexical/releases) to
+find out what the latest version is.
 
-If you wish to use any other version, it is required to build Lexical yourself. This isn't hard to do: clone the [Lexical language server repo](https://github.com/lexical-lsp/lexical), build a release following the instructions in the README and [configure the extension to use that local release](#lexicalserverreleasepathoverride).
+If you wish to use any other version, it is required to build Lexical yourself.
+This isn't hard to do: clone the
+[Lexical language server repo](https://github.com/lexical-lsp/lexical), build a
+release following the instructions in the README and
+[configure the extension to use that local release](#lexicalserverreleasepathoverride).
 
-Finally, even when building yourself, you are by default limited to using only the version of Erlang you built Lexical with. To enable your projects to use different versions, follow the above steps to build Lexical yourself, but change `include_erts` to `true` in `mix.exs` before building the release.
+Finally, even when building yourself, you are by default limited to using only
+the version of Erlang you built Lexical with. To enable your projects to use
+different versions, follow the above steps to build Lexical yourself, but change
+`include_erts` to `true` in `mix.exs` before building the release.
 
-The following table illustrates which versions of Erlang Lexical is compatible with when building yourself.
+The following table illustrates which versions of Erlang Lexical is compatible
+with when building yourself.
 
 | Erlang | Version range  | Notes                                                                      |
 | ------ | -------------- | -------------------------------------------------------------------------- |
@@ -52,7 +74,9 @@ The following table illustrates which versions of Erlang Lexical is compatible w
 
 #### Elixir
 
-Lexical has much less strict requirements on the version of Elixir. Any supported version of Elixir should work with any build of Lexical, auto-installed or not. The supported versions of Elixir are as follows:
+Lexical has much less strict requirements on the version of Elixir. Any
+supported version of Elixir should work with any build of Lexical,
+auto-installed or not. The supported versions of Elixir are as follows:
 
 | Elixir | Version Range | Notes                                                                     |
 | ------ | ------------- | ------------------------------------------------------------------------- |
@@ -64,21 +88,31 @@ Lexical has much less strict requirements on the version of Elixir. Any supporte
 
 Lexical outputs logs to two different files:
 
-- `lexical.log`: Contains logs for the language server node, which handles all the LSP communication, code intelligence, etc.
-- `project.log`: Contains logs for the project node, which handles loading and compiling your project.
+- `lexical.log`: Contains logs for the language server node, which handles all
+  the LSP communication, code intelligence, etc.
+- `project.log`: Contains logs for the project node, which handles loading and
+  compiling your project.
 
-Additionally, the Lexical channel in VSCode's Output tab may contain some pertinent information, notably when Lexical fails to start whatsoever (no log files are created).
+Additionally, the Lexical channel in VSCode's Output tab may contain some
+pertinent information, notably when Lexical fails to start whatsoever (no log
+files are created).
 
 ### Known issues
 
 #### `init terminating in do_boot ({load_failed,[logger_simple_h,gen,logger_server,...`
 
-When seeing this error in VSCode's Output tab, it most likely means your version of Erlang is incompatible with your build of Lexical. Please refer to the [Erlang compatibility section](#erlang) for more details.
+When seeing this error in VSCode's Output tab, it most likely means your version
+of Erlang is incompatible with your build of Lexical. Please refer to the
+[Erlang compatibility section](#erlang) for more details.
 
 ### Getting help
 
-If you have questions or need help, please refer to one of the following channels:
+If you have questions or need help, please refer to one of the following
+channels:
 
-- The [issues on the vscode-lexical project](https://github.com/lexical-lsp/vscode-lexical/issues)
-- The [issues on the lexical project](https://github.com/lexical-lsp/lexical/issues)
-- The `#editor-tooling` channel in the [Elixir Discord server](https://discord.gg/elixir)
+- The
+  [issues on the vscode-lexical project](https://github.com/lexical-lsp/vscode-lexical/issues)
+- The
+  [issues on the lexical project](https://github.com/lexical-lsp/lexical/issues)
+- The `#editor-tooling` channel in the
+  [Elixir Discord server](https://discord.gg/elixir)

--- a/README.md
+++ b/README.md
@@ -25,16 +25,24 @@ Tells the extension to use a local release of the Lexical language server instea
 
 The path should look something like `/home/username/Projects/lexical/_build/dev/rel/lexical`.
 
-## Troubleshooting
+### Erlang and Elixir version compatibility
 
-Lexical outputs logs to two different files:
+#### Erlang
 
-- `lexical.log`: Contains logs for the language server node, which handles all the LSP communication, code intelligence, etc.
-- `project.log`: Contains logs for the project node, which handles loading and compiling your project.
+Auto-installed builds of Lexical are currently only compatible with the version of Erlang they are built with. Refer to the following table to know which version that is:
 
-### Known issues
+| Lexical  | Erlang    |
+| -------- | --------- |
+| 0.2.2    | 24.3.4.13 |
+| >= 0.2.3 | 24.3.4.12 |
 
-Lexical supports the following versions of Elixir and Erlang:
+Refer to the [Releases page of Lexical](https://github.com/lexical-lsp/lexical/releases) to find out what the latest version is.
+
+If you wish to use any other version, it is required to build Lexical yourself. This isn't hard to do: clone the [Lexical language server repo](https://github.com/lexical-lsp/lexical), build a release following the instructions in the README and [configure the extension to use that local release](#lexicalserverreleasepathoverride).
+
+Finally, even when building yourself, you are by default limited to using only the version of Erlang you built Lexical with. To enable your projects to use different versions, follow the above steps to build Lexical yourself, but change `include_erts` to `true` in `mix.exs` before building the release.
+
+The following table illustrates which versions of Erlang Lexical is compatible with when building yourself.
 
 | Erlang | Version range  | Notes                                                                      |
 | ------ | -------------- | -------------------------------------------------------------------------- |
@@ -42,13 +50,30 @@ Lexical supports the following versions of Elixir and Erlang:
 | 25     | `>= 25.0`      |                                                                            |
 | 26     | In progress    |                                                                            |
 
+#### Elixir
+
+Lexical has much less strict requirements on the version of Elixir. Any supported version of Elixir should work with any build of Lexical, auto-installed or not. The supported versions of Elixir are as follows:
+
 | Elixir | Version Range | Notes                                                                     |
 | ------ | ------------- | ------------------------------------------------------------------------- |
 | 1.13   | `>= 1.13.4`   |                                                                           |
 | 1.14   | `all`         |                                                                           |
 | 1.15   | `>= 1.15.3`   | `1.15.0` - `1.15.2` had compiler bugs that prevented lexical from working |
 
-If you cannot use one of the above versions of Erlang, a workaround is to clone the [Lexical language server repo](https://github.com/lexical-lsp/lexical), change `include_erts` to `true` in `mix.exs`, build a release following the instructions in the README and [configure the extension to use that local release](#lexicalserverreleasepathoverride)
+## Troubleshooting
+
+Lexical outputs logs to two different files:
+
+- `lexical.log`: Contains logs for the language server node, which handles all the LSP communication, code intelligence, etc.
+- `project.log`: Contains logs for the project node, which handles loading and compiling your project.
+
+Additionally, the Lexical channel in VSCode's Output tab may contain some pertinent information, notably when Lexical fails to start whatsoever (no log files are created).
+
+### Known issues
+
+#### `init terminating in do_boot ({load_failed,[logger_simple_h,gen,logger_server,...`
+
+When seeing this error in VSCode's Output tab, it most likely means your version of Erlang is incompatible with your build of Lexical. Please refer to the [Erlang compatibility section](#erlang) for more details.
 
 ### Getting help
 

--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -3,40 +3,61 @@
 ## What's in the folder
 
 - This folder contains all of the files necessary for your extension.
-- `package.json` - this is the manifest file in which you declare your extension and command.
-  - The sample plugin registers a command and defines its title and command name. With this information VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
-- `src/extension.ts` - this is the main file where you will provide the implementation of your command.
-  - The file exports one function, `activate`, which is called the very first time your extension is activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
-  - We pass the function containing the implementation of the command as the second parameter to `registerCommand`.
+- `package.json` - this is the manifest file in which you declare your extension
+  and command.
+  - The sample plugin registers a command and defines its title and command
+    name. With this information VS Code can show the command in the command
+    palette. It doesn’t yet need to load the plugin.
+- `src/extension.ts` - this is the main file where you will provide the
+  implementation of your command.
+  - The file exports one function, `activate`, which is called the very first
+    time your extension is activated (in this case by executing the command).
+    Inside the `activate` function we call `registerCommand`.
+  - We pass the function containing the implementation of the command as the
+    second parameter to `registerCommand`.
 
 ## Get up and running straight away
 
 - Press `F5` to open a new window with your extension loaded.
-- Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
-- Set breakpoints in your code inside `src/extension.ts` to debug your extension.
+- Run your command from the command palette by pressing (`Ctrl+Shift+P` or
+  `Cmd+Shift+P` on Mac) and typing `Hello World`.
+- Set breakpoints in your code inside `src/extension.ts` to debug your
+  extension.
 - Find output from your extension in the debug console.
 
 ## Make changes
 
-- You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
-- You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+- You can relaunch the extension from the debug toolbar after changing code in
+  `src/extension.ts`.
+- You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your
+  extension to load your changes.
 
 ## Explore the API
 
-- You can open the full set of our API when you open the file `node_modules/@types/vscode/index.d.ts`.
+- You can open the full set of our API when you open the file
+  `node_modules/@types/vscode/index.d.ts`.
 
 ## Run tests
 
-- Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
+- Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the
+  launch configuration dropdown pick `Extension Tests`.
 - Press `F5` to run the tests in a new window with your extension loaded.
 - See the output of the test result in the debug console.
-- Make changes to `src/test/suite/extension.test.ts` or create new test files inside the `test/suite` folder.
-  - The provided test runner will only consider files matching the name pattern `**.test.ts`.
-  - You can create folders inside the `test` folder to structure your tests any way you want.
+- Make changes to `src/test/suite/extension.test.ts` or create new test files
+  inside the `test/suite` folder.
+  - The provided test runner will only consider files matching the name pattern
+    `**.test.ts`.
+  - You can create folders inside the `test` folder to structure your tests any
+    way you want.
 
 ## Go further
 
-- [Follow UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to create extensions that seamlessly integrate with VS Code's native interface and patterns.
-- Reduce the extension size and improve the startup time by [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).
-- [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VS Code extension marketplace.
-- Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).
+- [Follow UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)
+  to create extensions that seamlessly integrate with VS Code's native interface
+  and patterns.
+- Reduce the extension size and improve the startup time by
+  [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).
+- [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)
+  on the VS Code extension marketplace.
+- Automate builds by setting up
+  [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).


### PR DESCRIPTION
This adds some clarifications in the Readme regarding Erlang compatibility, auto-installed version requirements, `include_erts`, etc.

First commit includes clarifications in the Readme. Second commit is just a bunch of formatting following a newly enabled Prettier option.