### PR TITLE
Updated release path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,20 @@ to your own build with the
 
 Tells the extension to use a local release of the Lexical language server
 instead of the automatically installed one. Useful to work on Lexical, or use an
-older version.
+older version. This path can point to a directory that holds the lexical start script
+(assumed to be `start_lexical.sh`) or any executable launcher script.
 
 The path should look something like
-`/home/username/Projects/lexical/_build/dev/rel/lexical`.
+`/home/username/Projects/lexical/_build/dev/package/lexical/bin/start_lexical.sh`.
 
 ### Erlang and Elixir version compatibility
 
 #### Erlang
 
-Auto-installed builds of Lexical are currently only compatible with the version
-of Erlang they are built with. Refer to the following table to know which
-version that is:
+Auto-installed builds of Lexical are compatible with Elixir and Erlang versions
+that are newer than the version the build was built with.
+
+Refer to the following table to know which version that is:
 
 | Lexical  | Erlang    |
 | -------- | --------- |
@@ -52,16 +54,14 @@ Refer to the
 [Releases page of Lexical](https://github.com/lexical-lsp/lexical/releases) to
 find out what the latest version is.
 
-If you wish to use any other version, it is required to build Lexical yourself.
+These versions are a couple years old, and if you are using newer versions of Elixir and
+Erlang and Elixir in your projects, perfomrance will likely be better if you
+built Lexical yourself with a newer version of Elixir and Erlang.
+
 This isn't hard to do: clone the
 [Lexical language server repo](https://github.com/lexical-lsp/lexical), build a
 release following the instructions in the README and
 [configure the extension to use that local release](#lexicalserverreleasepathoverride).
-
-Finally, even when building yourself, you are by default limited to using only
-the version of Erlang you built Lexical with. To enable your projects to use
-different versions, follow the above steps to build Lexical yourself, but change
-`include_erts` to `true` in `mix.exs` before building the release.
 
 The following table illustrates which versions of Erlang Lexical is compatible
 with when building yourself.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ to your own build with the
 
 Tells the extension to use a local release of the Lexical language server
 instead of the automatically installed one. Useful to work on Lexical, or use an
-older version. This path can point to a directory that holds the lexical start script
-(assumed to be `start_lexical.sh`) or any executable launcher script.
+older version. This path can point to a directory that holds the lexical start
+script (assumed to be `start_lexical.sh`) or any executable launcher script.
 
 The path should look something like
 `/home/username/Projects/lexical/_build/dev/package/lexical/bin/start_lexical.sh`.
@@ -54,9 +54,9 @@ Refer to the
 [Releases page of Lexical](https://github.com/lexical-lsp/lexical/releases) to
 find out what the latest version is.
 
-These versions are a couple years old, and if you are using newer versions of Elixir and
-Erlang and Elixir in your projects, perfomrance will likely be better if you
-built Lexical yourself with a newer version of Elixir and Erlang.
+These versions are a couple years old, and if you are using newer versions of
+Elixir and Erlang and Elixir in your projects, perfomrance will likely be better
+if you built Lexical yourself with a newer version of Elixir and Erlang.
 
 This isn't hard to do: clone the
 [Lexical language server repo](https://github.com/lexical-lsp/lexical), build a

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "lexical.server.releasePathOverride": {
           "scope": "window",
           "type": "string",
-          "markdownDescription": "The path to the lexical release the extension should start. The path should point to a folder containing the `start_lexical.sh` script. Note that setting this to any value will disable automatic installation of Lexical."
+          "markdownDescription": "The path to the lexical executable. The path should point to a folder containing the `start_lexical.sh` or an executable file. Note that setting this to any value will disable automatic installation of Lexical."
         }
       }
     }

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -14,10 +14,23 @@ import ReleaseVersion from "./release/version";
 import extract = require("extract-zip");
 
 namespace LanguageServer {
+	function isExecutableFile(path: fs.PathLike): boolean {
+		const stat = fs.lstatSync(path);
+		let access = false;
+		try {
+			fs.accessSync(path, fs.constants.R_OK);
+			access = true;
+		} catch (e) {
+			access = false;
+		}
+		return stat.isFile() && access;
+	}
+
 	export async function start(releasePath: string): Promise<void> {
 		const outputChannel = window.createOutputChannel("Lexical");
-
-		const startScriptPath = join(releasePath, "start_lexical.sh");
+		const startScriptPath = isExecutableFile(releasePath)
+			? releasePath
+			: join(releasePath, "start_lexical.sh");
 
 		const serverOptions: ServerOptions = {
 			command: startScriptPath,

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -16,14 +16,14 @@ import extract = require("extract-zip");
 namespace LanguageServer {
 	function isExecutableFile(path: fs.PathLike): boolean {
 		const stat = fs.lstatSync(path);
-		let access = false;
+		let hasExecuteAccess = false;
 		try {
-			fs.accessSync(path, fs.constants.R_OK);
-			access = true;
+			fs.accessSync(path, fs.constants.X_OK);
+			hasExecuteAccess = true;
 		} catch (e) {
-			access = false;
+			hasExecuteAccess = false;
 		}
-		return stat.isFile() && access;
+		return stat.isFile() && hasExecuteAccess;
 	}
 
 	export async function start(releasePath: string): Promise<void> {


### PR DESCRIPTION
Prior, the release path assumed a directory and appended `start_lexical.sh` to it. This meant that the name of the executable was hardcoded in the extension, and that made playing around with packaging tougher. It would also mean that getting lexical to run on windows would be harder.

This PR maintains backwards compatibility with the old pattern where you can specify a directory, but also adds the ability to point to an executable file.