### PR TITLE
Mark quoted atoms and sigils as strings for bracket matching

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -600,7 +600,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -624,7 +624,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -648,7 +648,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -672,7 +672,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -696,7 +696,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -720,7 +720,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -744,7 +744,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -768,7 +768,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -792,7 +792,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -816,7 +816,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -840,7 +840,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with pipes",
@@ -856,7 +856,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with parens",
@@ -872,7 +872,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with curlies",
@@ -888,7 +888,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with curlies",
@@ -904,7 +904,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with curlies",
@@ -920,7 +920,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with single quoted heredoc",
@@ -936,7 +936,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with double quoted heredoc",
@@ -952,7 +952,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with curlies",
@@ -968,7 +968,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "comment": "Literal Character list sigil with curlies",
@@ -984,7 +984,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir"
+      "name": "support.function.variable.quoted.single.string.elixir"
     },
     {
       "begin": "~w\\{",
@@ -2064,7 +2064,7 @@
         }
       },
       "end": "'",
-      "name": "constant.language.symbol.single-quoted.elixir",
+      "name": "constant.language.symbol.single-quoted.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -2105,7 +2105,7 @@
         }
       },
       "end": "\"",
-      "name": "constant.language.symbol.double-quoted.elixir",
+      "name": "constant.language.symbol.double-quoted.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -2129,7 +2129,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.heredoc.elixir",
+      "name": "support.function.variable.quoted.single.heredoc.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -2153,7 +2153,7 @@
           "name": "punctuation.definition.string.end.elixir"
         }
       },
-      "name": "support.function.variable.quoted.single.elixir",
+      "name": "support.function.variable.quoted.single.string.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"


### PR DESCRIPTION
VS Code supports build-in bracket matching, highlighting matching pairs and supporting features like go-to-matching-bracket. To differentiate between significant and non-significant brackets (e.g. those in strings), VS Code looks for a `string` segment in the token name.

A lot of "string-like" Elixir syntax didn't have that `string` segment, which is added in this commit.

The approach I took is to append `string` as far towards the end of the name, but before `elixir`, so that as much existing syntax highlighting remains the same. (Syntax highlighting rules use a prefix match.)

I believe that some names could be replaced entirely for more accurate ones, but I don't think they should be changed at this point for compatibility reasons. (For example, `support.function.variable.quoted.single.string.elixir` should probably just be `string.quoted.single.elixir`.)

**Before (note the incorrect paren matching):**

![string-tokens-before](https://github.com/lexical-lsp/vscode-lexical/assets/503938/f7abb9e2-7fbb-400e-9507-f52146882d77)

**After:**

![string-tokens-after](https://github.com/lexical-lsp/vscode-lexical/assets/503938/d714f442-ebf9-4a69-ba02-a9bbf309c555)
