### PR TITLE
feat: Provide restart command

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,14 @@
           "markdownDescription": "The path to the lexical executable. The path should point to a folder containing the `start_lexical.sh` or an executable file. Note that setting this to any value will disable automatic installation of Lexical."
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "lexical.server.restart",
+        "category": "Lexical",
+        "title": "Restart Lexical's language server"
+      }
+    ]
   },
   "scripts": {
     "test-compile": "tsc -p ./src/test-e2e --outDir ./out/test-e2e && yarn esbuild && rm -rf ./out/test-e2e/fixtures && cp -r ./src/test-e2e/fixtures ./out/test-e2e/fixtures",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,22 @@
+namespace Commands {
+	type CommandHandler = () => void;
+
+	type RegisterFunction = <Context>(
+		command: T<Context>,
+		context: Context
+	) => void;
+
+	export interface T<Context> {
+		id: string;
+		createHandler: (context: Context) => CommandHandler;
+	}
+
+	export function getRegisterFunction(
+		clientRegister: (id: string, handler: CommandHandler) => void
+	): RegisterFunction {
+		return <Context>(command: T<Context>, context: Context) =>
+			clientRegister(command.id, command.createHandler(context));
+	}
+}
+
+export default Commands;

--- a/src/commands/restart-server.ts
+++ b/src/commands/restart-server.ts
@@ -1,0 +1,24 @@
+import { LanguageClient } from "vscode-languageclient/node";
+import Commands from ".";
+
+interface Context {
+	client: LanguageClient;
+	showWarning: (message: string) => void;
+}
+
+const restartServer: Commands.T<Context> = {
+	id: "lexical.server.restart",
+	createHandler: ({ client, showWarning }) => {
+		function handle() {
+			if (client.isRunning()) {
+				client.restart();
+			} else {
+				showWarning("Server is not running, cannot restart.");
+			}
+		}
+
+		return handle;
+	},
+};
+
+export default restartServer;

--- a/src/test/commands/index.test.ts
+++ b/src/test/commands/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import Commands from "../../commands";
+
+describe("Commands", () => {
+	describe("getRegisterFunction", () => {
+		test("returns a function that registers the command with the client when called", () => {
+			const clientRegister = jest.fn();
+			const register = Commands.getRegisterFunction(clientRegister);
+
+			register(commandStub, undefined);
+
+			expect(clientRegister).toHaveBeenCalledWith(commandStub.id, handler);
+		});
+	});
+});
+
+const handler = jest.fn();
+
+const commandStub: Commands.T<undefined> = {
+	id: "stub",
+	createHandler: () => handler,
+};

--- a/src/test/commands/restart-server.test.ts
+++ b/src/test/commands/restart-server.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import restartServer from "../../commands/restart-server";
+import { LanguageClient } from "vscode-languageclient/node";
+
+describe("restartServer", () => {
+	test("restarts the language client", () => {
+		const restart = jest.fn<LanguageClient["restart"]>();
+		const handler = restartServer.createHandler({
+			client: getClientStub(true, restart),
+			showWarning: jest.fn(),
+		});
+
+		handler();
+
+		expect(restart).toHaveBeenCalled();
+	});
+
+	test("given the client is not running, shows a warning", () => {
+		const showWarning = jest.fn();
+		const handler = restartServer.createHandler({
+			client: getClientStub(false, jest.fn<LanguageClient["restart"]>()),
+			showWarning: showWarning,
+		});
+
+		handler();
+
+		expect(showWarning).toHaveBeenCalled();
+	});
+});
+
+function getClientStub(
+	isRunning: boolean,
+	restart: LanguageClient["restart"]
+): LanguageClient {
+	return {
+		isRunning() {
+			return isRunning;
+		},
+		restart,
+	} as unknown as LanguageClient;
+}


### PR DESCRIPTION
Adds a command to restart the language server without reloading vscode as a whole.

Also adds basic infrastructure to easily add other commands in the future.

Fixes #3