### PR TITLE
fix: Fixes restart command being unavailable if initial start failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - The `Restart Lexical's language server` command now starts the language server
-  if it isn't already running. Useful to quicly restart Lexical if initial start
+  if it isn't already running. Useful to quickly restart Lexical if initial start
   failed due to environment reasons, like an incompatible version of Erlang or
   Elixir.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+- The `Restart Lexical's language server` command now starts the language server
+  if it isn't already running. Useful to quicly restart Lexical if initial start
+  failed due to environment reasons, like an incompatible version of Erlang or
+  Elixir.
+
 ## [0.0.11]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Added
 
 - The `Restart Lexical's language server` command now starts the language server
-  if it isn't already running. Useful to quickly restart Lexical if initial start
-  failed due to environment reasons, like an incompatible version of Erlang or
-  Elixir.
+  if it isn't already running. Useful to quickly restart Lexical if initial
+  start failed due to environment reasons, like an incompatible version of
+  Erlang or Elixir.
 
 ## [0.0.11]
 

--- a/src/commands/restart-server.ts
+++ b/src/commands/restart-server.ts
@@ -3,17 +3,18 @@ import Commands from ".";
 
 interface Context {
 	client: LanguageClient;
-	showWarning: (message: string) => void;
 }
 
 const restartServer: Commands.T<Context> = {
 	id: "lexical.server.restart",
-	createHandler: ({ client, showWarning }) => {
+	createHandler: ({ client }) => {
 		function handle() {
 			if (client.isRunning()) {
+				console.log("Lexical client is already running. Restarting.");
 				client.restart();
 			} else {
-				showWarning("Server is not running, cannot restart.");
+				console.log("Lexical client is not running. Starting.");
+				client.start();
 			}
 		}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
 			context.subscriptions.push(commands.registerCommand(id, handler));
 		});
 
-		if (client !== undefined) {
-			registerCommand(restartServer, {
-				client,
-				showWarning: window.showWarningMessage,
-			});
-		}
+		registerCommand(restartServer, {
+			client,
+		});
 	}
 }
 
@@ -73,7 +70,7 @@ function isExecutableFile(path: fs.PathLike): boolean {
 
 async function start(
 	startScriptOrReleaseFolderPath: string
-): Promise<LanguageClient | undefined> {
+): Promise<LanguageClient> {
 	const outputChannel = window.createOutputChannel("Lexical");
 	const startScriptPath = isExecutableFile(startScriptOrReleaseFolderPath)
 		? startScriptOrReleaseFolderPath
@@ -114,7 +111,6 @@ async function start(
 		await client.start();
 	} catch (reason) {
 		window.showWarningMessage(`Failed to start Lexical: ${reason}`);
-		return undefined;
 	}
 
 	return client;

--- a/src/test/commands/restart-server.test.ts
+++ b/src/test/commands/restart-server.test.ts
@@ -3,11 +3,10 @@ import restartServer from "../../commands/restart-server";
 import { LanguageClient } from "vscode-languageclient/node";
 
 describe("restartServer", () => {
-	test("restarts the language client", () => {
+	test("given it is running, restarts it", () => {
 		const restart = jest.fn<LanguageClient["restart"]>();
 		const handler = restartServer.createHandler({
-			client: getClientStub(true, restart),
-			showWarning: jest.fn(),
+			client: getClientStub({ isRunning: true, restart }),
 		});
 
 		handler();
@@ -15,27 +14,32 @@ describe("restartServer", () => {
 		expect(restart).toHaveBeenCalled();
 	});
 
-	test("given the client is not running, shows a warning", () => {
-		const showWarning = jest.fn();
+	test("given the client is not running, starts it", () => {
+		const start = jest.fn<LanguageClient["restart"]>();
 		const handler = restartServer.createHandler({
-			client: getClientStub(false, jest.fn<LanguageClient["restart"]>()),
-			showWarning: showWarning,
+			client: getClientStub({ isRunning: false, start }),
 		});
 
 		handler();
 
-		expect(showWarning).toHaveBeenCalled();
+		expect(start).toHaveBeenCalled();
 	});
 });
 
-function getClientStub(
-	isRunning: boolean,
-	restart: LanguageClient["restart"]
-): LanguageClient {
+function getClientStub({
+	isRunning,
+	restart = jest.fn<LanguageClient["restart"]>(),
+	start = jest.fn<LanguageClient["start"]>(),
+}: {
+	isRunning: boolean;
+	restart?: LanguageClient["restart"];
+	start?: LanguageClient["start"];
+}): LanguageClient {
 	return {
 		isRunning() {
 			return isRunning;
 		},
 		restart,
+		start,
 	} as unknown as LanguageClient;
 }


### PR DESCRIPTION
Always register the restart command regardless of whether the client managed to start or not.
Also, the restart command will attempt to start the language client if it is not already running instead of showing a warning.

Fixes #62 