### PR TITLE
Heredoc markdown syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+- Identify contents of documentation attributes (`@doc`, `@moduledoc` and
+  `@typedoc`) as Markdown, thus enabling Markdown syntax highlighting.
+
 ## [0.0.18]
 
 ### Fixed

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -20,71 +20,136 @@
       "name": "meta.module.elixir"
     },
     {
-      "begin": "@(module|type)?doc (~s)?\"\"\"",
+      "begin": "@(?:module|type)?doc (?:~s)?\"\"\"",
       "comment": "@doc with interpolated heredocs",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~s'''",
+      "begin": "@(?:module|type)?doc ~s'''",
       "comment": "@doc with interpolated single quoted heredocs",
       "end": "\\s*'''",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~S\"\"\"",
+      "begin": "@(?:module|type)?doc ~S\"\"\"",
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~S'''",
+      "begin": "@(?:module|type)?doc ~S'''",
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*'''",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },
     {
       "comment": "@doc false is treated as documentation",
-      "match": "@(module|type)?doc false",
+      "match": "@(?:module|type)?doc false",
       "name": "comment.documentation.false"
     },
     {
-      "begin": "@(module|type)?doc \"",
+      "begin": "@(?:module|type)?doc \"",
       "comment": "@doc with string is treated as documentation",
       "end": "\"",
-      "name": "comment.documentation.string",
+      "name": "documentation.string",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -24,12 +24,7 @@
       "comment": "@doc with interpolated heredocs",
       "end": "\\s*\"\"\"",
       "name": "documentation.heredoc.elixir",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
+      "captures": {
         "0": {
           "name": "comment"
         }
@@ -51,12 +46,7 @@
       "comment": "@doc with interpolated single quoted heredocs",
       "end": "\\s*'''",
       "name": "documentation.heredoc.elixir",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
+      "captures": {
         "0": {
           "name": "comment"
         }
@@ -78,12 +68,7 @@
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*\"\"\"",
       "name": "documentation.heredoc.elixir",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
+      "captures": {
         "0": {
           "name": "comment"
         }
@@ -102,12 +87,7 @@
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*'''",
       "name": "documentation.heredoc.elixir",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
+      "captures": {
         "0": {
           "name": "comment"
         }
@@ -131,12 +111,7 @@
       "comment": "@doc with string is treated as documentation",
       "end": "\"",
       "name": "documentation.string",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
+      "captures": {
         "0": {
           "name": "comment"
         }


### PR DESCRIPTION
Injects the Markdown grammar into heredoc for `@doc`, `@moduledoc` and `@typedoc` attributes. This enables markdown syntax highlighting for these blocks.

Fixes #87