### PR TITLE
Add markdown highlighting for @docs @moduledocs and @typedocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# [Unreleased]
+
+### Added
+
+- Added syntax highlighting for markdown in `@doc`, `@moduledoc` and `@typedoc` modules attributes. All credits for this solution belong to @SteffenDE
 ## [0.0.18]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Added syntax highlighting for markdown in `@doc`, `@moduledoc` and `@typedoc` modules attributes. All credits for this solution belong to @SteffenDE
+- Added syntax highlighting for markdown in `@doc`, `@moduledoc` and `@typedoc` modules attributes. Thanks to @SteffenDE for suggesting the solution and @Terbium-135 for implementing it.
+
 ## [0.0.18]
 
 ### Fixed

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/refs/heads/master/tmlanguage.json",
   "comment": "Atom Syntax Parser for Elixir Programming Language.",
-  "fileTypes": [
-    "ex",
-    "exs"
-  ],
+  "fileTypes": ["ex", "exs"],
   "firstLineMatch": "^#!/.*\\belixir",
   "foldingStartMarker": "(after|else|catch|rescue|\\-\\>|\\{|\\[|do)\\s*$",
   "foldingStopMarker": "^\\s*((\\}|\\]|after|else|catch|rescue)\\s*$|end\\b)",

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/refs/heads/master/tmlanguage.json",
   "comment": "Atom Syntax Parser for Elixir Programming Language.",
-  "fileTypes": ["ex", "exs"],
+  "fileTypes": [
+    "ex",
+    "exs"
+  ],
   "firstLineMatch": "^#!/.*\\belixir",
   "foldingStartMarker": "(after|else|catch|rescue|\\-\\>|\\{|\\[|do)\\s*$",
   "foldingStopMarker": "^\\s*((\\}|\\]|after|else|catch|rescue)\\s*$|end\\b)",
@@ -20,71 +23,160 @@
       "name": "meta.module.elixir"
     },
     {
-      "begin": "@(module|type)?doc (~s)?\"\"\"",
+      "begin": "@(?:module|type)?doc (?:~s)?\"\"\"",
       "comment": "@doc with interpolated heredocs",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "begin": ".*",
+          "while": "(^|\\G)(?!\\s*\"\"\"\\s*$)",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            }
+          ]
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~s'''",
+      "begin": "@(?:module|type)?doc ~s'''",
       "comment": "@doc with interpolated single quoted heredocs",
       "end": "\\s*'''",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "begin": ".*",
+          "while": "(^|\\G)(?!\\s*'''\\s*$)",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            }
+          ]
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~S\"\"\"",
+      "begin": "@(?:module|type)?doc ~S\"\"\"",
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#escaped_char"
+        },
+        {
+          "begin": ".*",
+          "while": "(^|\\G)(?!\\s*\"\"\"\\s*$)",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            }
+          ]
         }
       ]
     },
     {
-      "begin": "@(module|type)?doc ~S'''",
+      "begin": "@(?:module|type)?doc ~S'''",
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*'''",
-      "name": "comment.documentation.heredoc.elixir",
+      "name": "documentation.heredoc.elixir",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#escaped_char"
+        },
+        {
+          "begin": ".*",
+          "while": "(^|\\G)(?!\\s*'''\\s*$)",
+          "patterns": [
+            {
+              "include": "text.html.markdown"
+            }
+          ]
         }
       ]
     },
     {
       "comment": "@doc false is treated as documentation",
-      "match": "@(module|type)?doc false",
+      "match": "@(?:module|type)?doc false",
       "name": "comment.documentation.false"
     },
     {
-      "begin": "@(module|type)?doc \"",
+      "begin": "@(?:module|type)?doc \"",
       "comment": "@doc with string is treated as documentation",
       "end": "\"",
-      "name": "comment.documentation.string",
+      "name": "documentation.string",
+      "beginCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "comment"
+        }
+      },
       "patterns": [
         {
           "include": "#interpolated_elixir"
         },
         {
           "include": "#escaped_char"
+        },
+        {
+          "include": "text.html.markdown"
         }
       ]
     },


### PR DESCRIPTION
All credits for this fix going to https://github.com/SteffenDE

Fixes https://github.com/lexical-lsp/vscode-lexical/issues/87