### PR TITLE
fix: hightlighting breaks after single line doc

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -154,17 +154,7 @@
       "begin": "@(?:module|type)?doc \"",
       "comment": "@doc with string is treated as documentation",
       "end": "\"",
-      "name": "documentation.string",
-      "beginCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
-      "endCaptures": {
-        "0": {
-          "name": "comment"
-        }
-      },
+      "name": "comment.documentation.string",
       "patterns": [
         {
           "include": "#interpolated_elixir"

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -171,9 +171,6 @@
         },
         {
           "include": "#escaped_char"
-        },
-        {
-          "include": "text.html.markdown"
         }
       ]
     },


### PR DESCRIPTION
Doc comments like `@doc "foo"` break syntax highlighting after 0.0.19

https://github.com/lexical-lsp/vscode-lexical/issues/91

## Before

**VSCode 1.96.2** and **Lexical 0.0.19**

![image](https://github.com/user-attachments/assets/078f6419-c0d1-414f-9be2-62d5c64a464f)

**Cursor 0.44.11** and **Lexical 0.0.19**

![image](https://github.com/user-attachments/assets/2aba9702-5653-4d61-b883-9c6349d73881)

## After

**Cursor 0.44.11**

![image](https://github.com/user-attachments/assets/aae38a23-1172-4918-b01e-c48ae21431bb)
